### PR TITLE
Define MIN_LEN constant

### DIFF
--- a/generate_conversations_index_clean.py
+++ b/generate_conversations_index_clean.py
@@ -9,6 +9,7 @@ OUTPUT_YAML = Path("IA_Florian/cache/conversations_index_clean.yaml")
 MAX_CONV = 40   # conversations maximum à indexer
 MAX_EXTRACT = 1 # messages par conversation
 MAX_LEN = 250   # longueur maximale de l'extrait
+MIN_LEN = 30    # longueur minimale d'un message retenu
 
 # === NOUVELLE LIMITE DE SÉCURITÉ GLOBALE (approximative) ===
 MAX_TOTAL_CHARS = 9000  # limite globale (≈ 3000 tokens GPT)


### PR DESCRIPTION
## Summary
- add `MIN_LEN` constant alongside other configs
- rely on `MIN_LEN` when extracting messages

## Testing
- `python -m py_compile generate_conversations_index_clean.py`
- `python generate_conversations_index_clean.py` *(fails: Fichier introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_684041411970832e9d76d89d802538e9