### PR TITLE
Fix typos in READMEs

### DIFF
--- a/IA_Florian/README.md
+++ b/IA_Florian/README.md
@@ -9,7 +9,7 @@ Ce répertoire constitue la base de fonctionnement de l'assistant personnel IA_F
 - `03_projets/` : fichiers liés aux projets actifs (discernement, STI, paroisse)
 - `04_templates/` : template de sortie
 - `05_archives/` : anciennes conversations, ...
-- `06_graphisme/` : prompst pour dall-e notemment
+- `06_graphisme/` : prompts pour dall-e notamment
 - `07_diffusion/` : anticipation d'envoi par IA
 - `automation/` : scripts shell d’export et de tâches automatisées
 - `cache/` : extrait pratique du conversations.json (trop lourd pour être traité en entier)

--- a/IA_Florian/liste_fichiers.txt
+++ b/IA_Florian/liste_fichiers.txt
@@ -6026,7 +6026,7 @@
      9	- `03_projets/` : fichiers liés aux projets actifs (discernement, STI, paroisse)
     10	- `04_templates/` : template de sortie
     11	- `05_archives/` : anciennes conversations, ...
-    12	- `06_graphisme/` : prompst pour dall-e notemment
+    12	- `06_graphisme/` : prompts pour dall-e notamment
     13	- `07_diffusion/` : anticipation d'envoi par IA
     14	- `automation/` : scripts shell d’export et de tâches automatisées
     15	- `cache/` : extrait pratique du conversations.json (trop lourd pour être traité en entier)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ce répertoire constitue la base de fonctionnement de l'assistant personnel IA_F
 - `03_projets/` : fichiers liés aux projets actifs (discernement, STI, paroisse)
 - `04_templates/` : template de sortie
 - `05_archives/` : anciennes conversations, ...
-- `06_graphisme/` : prompst pour dall-e notemment
+- `06_graphisme/` : prompts pour dall-e notamment
 - `07_diffusion/` : anticipation d'envoi par IA
 - `automation/` : scripts shell d’export et de tâches automatisées
 - `cache/` : extrait pratique du conversations.json (trop lourd pour être traité en entier)


### PR DESCRIPTION
## Summary
- fix typo in root README
- fix typo in `IA_Florian/README.md`
- fix typo in `IA_Florian/liste_fichiers.txt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68404128f2d4832ea724a1a59271b581