### PR TITLE
Fix context path and add missing MIN_LEN constant

### DIFF
--- a/generate_conversations_index_clean.py
+++ b/generate_conversations_index_clean.py
@@ -9,6 +9,7 @@ OUTPUT_YAML = Path("IA_Florian/cache/conversations_index_clean.yaml")
 MAX_CONV = 40   # conversations maximum à indexer
 MAX_EXTRACT = 1 # messages par conversation
 MAX_LEN = 250   # longueur maximale de l'extrait
+MIN_LEN = 30    # longueur minimale pour qu'un extrait soit conservé
 
 # === NOUVELLE LIMITE DE SÉCURITÉ GLOBALE (approximative) ===
 MAX_TOTAL_CHARS = 9000  # limite globale (≈ 3000 tokens GPT)

--- a/utils/context.py
+++ b/utils/context.py
@@ -3,7 +3,10 @@ import os
 import json
 from pathlib import Path
 
-CONTEXT_DIR = Path("IA_Florian/contextes")
+# Les contextes sont stockés à la racine du projet dans le dossier
+# `contextes`. L'ancien chemin "IA_Florian/contextes" n'existait pas et
+# entraînait la création involontaire d'un dossier inutile.
+CONTEXT_DIR = Path("contextes")
 CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
 
 def context_path(nom_session: str) -> Path:


### PR DESCRIPTION
## Summary
- fix wrong folder path in `utils/context.py`
- add `MIN_LEN` missing constant in `generate_conversations_index_clean.py`

## Testing
- `python -m py_compile generate_conversations_index_clean.py utils/context.py`

------
https://chatgpt.com/codex/tasks/task_e_68401e88c388832ea7133f8e3dec5dd2